### PR TITLE
Expand rationale to include known challenges with stub data

### DIFF
--- a/ERCS/erc-7677.md
+++ b/ERCS/erc-7677.md
@@ -289,7 +289,7 @@ Enabling a workflow with greater flexibility in gas estimations will nonetheless
 
 #### `PreVerificationGas`
 
-The `preVerificationGas` value is largely influenced by the size of the user operation and it's ratio of zero to non-zero bytes. This can cause a scenario where `pm_getPaymasterStubData` returns values that results in upstream gas estimations to derive a lower `preVerificationGas` compared to what `pm_getPaymasterData` would require. If this occurs then bundlers will return an insufficient `preVerificationGas` gas error during `eth_sendUserOperation`.
+The `preVerificationGas` value is largely influenced by the size of the user operation and it's ratio of zero to non-zero bytes. This can cause a scenario where `pm_getPaymasterStubData` returns values that results in upstream gas estimations to derive a lower `preVerificationGas` compared to what `pm_getPaymasterData` would require. If this occurs then bundlers will return an insufficient `preVerificationGas` error during `eth_sendUserOperation`.
 
 To avoid this scenario, a paymaster service must return stub data that:
 
@@ -298,7 +298,7 @@ To avoid this scenario, a paymaster service must return stub data that:
 
 #### Consistent code paths
 
-In the naive case, a stub value of repeating non-zero bytes (e.g. `0x01`) that is of the same length as the final value will generate a usable `preVerificationGas`. Although this would immediately result in a gas estimation errors given that the simulation will likely revert due to an invalid paymaster data.
+In the naive case, a stub value of repeating non-zero bytes (e.g. `0x01`) that is of the same length as the final value will generate a usable `preVerificationGas`. Although this would immediately result in a gas estimation error given that the simulation will likely revert due to an invalid paymaster data.
 
 In a more realistic case, a valid stub can result in a successful simulation but still return insufficient gas limits. This can occur if the stub data causes `validatePaymasterUserOp` or `postOp` functions to simulate a different code path compared to the final value. For example, if the simulated code was to return early, the estimated gas limits would be less than expected which would cause upstream `out of gas` errors once a user operation is submitted to the bundler.
 

--- a/ERCS/erc-7677.md
+++ b/ERCS/erc-7677.md
@@ -281,7 +281,28 @@ Below is a diagram illustrating the full `wallet_sendCalls` flow, including how 
 
 ### Gas Estimation
 
-The current loose standard for paymaster services is to implement `pm_sponsorUserOperation`. This method returns values for paymaster-realted user operation fields and updated gas values. The problem with this method is that paymaster service providers have different ways of estimating gas, which results in different estimated gas values. Sometimes these estimates can be insufficient. As a result we believe it’s better to leave gas estimation up to the wallet, as the wallet has more context on how user operations will get submitted (e.g. which bundler they will get submitted to). Then wallets can ask paymaster services to sponsor given the estimates defined by the wallet.
+The current loose standard for paymaster services is to implement `pm_sponsorUserOperation`. This method returns values for paymaster-related user operation fields and updated gas values. The problem with this method is that paymaster service providers have different ways of estimating gas, which results in different estimated gas values. Sometimes these estimates can be insufficient. As a result we believe it’s better to leave gas estimation up to the wallet, as the wallet has more context on how user operations will get submitted (e.g. which bundler they will get submitted to). Then wallets can ask paymaster services to sponsor given the estimates defined by the wallet.
+
+### Challenges with stub data
+
+Enabling a workflow with greater flexibility in gas estimations will nonetheless come with some known challenges that paymaster services must be aware of in order to ensure reliable gas estimates are generated during the process.
+
+#### `PreVerificationGas`
+
+The `preVerificationGas` value is largely influenced by the size of the user operation and it's ratio of zero to non-zero bytes. This can cause a scenario where `pm_getPaymasterStubData` returns values that results in upstream gas estimations to derive a lower `preVerificationGas` compared to what `pm_getPaymasterData` would require. If this occurs then bundlers will return an insufficient `preVerificationGas` gas error during `eth_sendUserOperation`.
+
+To avoid this scenario, a paymaster service must return stub data that:
+
+1. Is of the same length as the final data.
+2. Has an amount of zero bytes (`0x00`) that is less than or equal to the final data.
+
+#### Consistent code paths
+
+In the naive case, a stub value of repeating non-zero bytes (e.g. `0x01`) that is of the same length as the final value will generate a usable `preVerificationGas`. Although this would immediately result in a gas estimation errors given that the simulation will likely revert due to an invalid paymaster data.
+
+In a more realistic case, a valid stub can result in a successful simulation but still return insufficient gas limits. This can occur if the stub data causes `validatePaymasterUserOp` or `postOp` functions to simulate a different code path compared to the final value. For example, if the simulated code was to return early, the estimated gas limits would be less than expected which would cause upstream `out of gas` errors once a user operation is submitted to the bundler.
+
+Therefore, a paymaster service must also return a stub that can result in a simulation executing the same code path compared to what is expected of the final user operation.
 
 ## Security Considerations
 


### PR DESCRIPTION
This PR expands the rationale section for ERC-7677 to include details regarding known challenges with using stub data and maintaining reliable gas estimations.

Also fixed a small typo in the gas estimation section (i.e "paymaster-realted" to "paymaster-related").