### PR TITLE
feat: suggestions

### DIFF
--- a/ERCS/erc-7836.md
+++ b/ERCS/erc-7836.md
@@ -17,7 +17,7 @@ This proposal defines complementary JSON-RPC methods to [EIP-5792's `wallet_send
 
 ## Motivation
 
-With the advent of Account Abstraction (and Account Permissions), there is an increasing need for Applications to be able to sign and submit actions without needing to switch to a Wallet interface (e.g. browser extension). As Smart Contract Accounts (SCAs) contain opinionated execution interfaces that leads to varying calldata formats, it is not possible for an Application to know how to sign over an action for any arbitrary Account implementation. They would need to maintain a mapping of Account implementations to their signing logic.
+With the advent of Account Abstraction (and Permissions), there is an increasing need for Applications to be able to sign and submit actions without needing to switch to a Wallet interface (e.g. browser extension). As Smart Contract Accounts (SCAs) contain opinionated execution interfaces that leads to varying calldata formats, it is not possible for an Application to know how to sign over an action for any arbitrary Account implementation. They would need to maintain a mapping of Account implementations to their signing logic.
 
 ## Specification
 

--- a/ERCS/erc-7836.md
+++ b/ERCS/erc-7836.md
@@ -128,6 +128,8 @@ type Request = {
     context: unknown
     // Signature of the call bundle.
     signature: {
+      // Public key that generated the signature.
+      publicKey: `0x${string}`,
       // Signature type (e.g. secp256k1, p256, etc).
       type: string,
       // Signature value.
@@ -177,6 +179,7 @@ const response = await provider.request({
   params: [{
     ...request,
     signature: {
+      publicKey: '0x...',
       type: 'p256',
       value: signature,
     }

--- a/ERCS/erc-7836.md
+++ b/ERCS/erc-7836.md
@@ -52,10 +52,12 @@ type Request = {
     from?: `0x${string}`;
     // Key that will be used to sign the call bundle.
     key?: {
+      // Whether the digest will be prehashed by the key (default behavior of WebCrypto APIs).
+      prehash: boolean,
       // Public key.
       publicKey: `0x${string}`,
       // Key type.
-      type: 'secp256k1' | 'p256' | 'webauthn-p256' | 'webcrypto-p256'
+      type: 'secp256k1' | 'p256' | 'webauthn-p256'
     };
     // JSON-RPC method version.
     version: string;
@@ -78,6 +80,8 @@ type Response = {
   context: unknown
   // Key that will be used to sign the call bundle.
   key: {
+    // Whether the digest will be prehashed by the key (default behavior of WebCrypto APIs).
+    prehash: boolean,
     // Public key.
     publicKey: `0x${string}`,
     // Key type.
@@ -107,6 +111,7 @@ const response = await provider.request({
     },
     chainId: '0x1',
     key: {
+      prehash: false,
       publicKey: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
       type: 'p256',
     },
@@ -124,6 +129,7 @@ const response = await provider.request({
  *   context: { ... },
  *   digest: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
  *   key: {
+ *     prehash: false,
  *     publicKey: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
  *     type: 'p256',
  *   },
@@ -153,6 +159,8 @@ type Request = {
     context: unknown
     // Key that was used to sign the call bundle.
     key: {
+      // Whether the digest will be prehashed by the key (default behavior of WebCrypto APIs).
+      prehash: boolean,
       // Public key.
       publicKey: `0x${string}`,
       // Key type.
@@ -194,6 +202,7 @@ const { digest, ...request } = await provider.request({
     },
     chainId: '0x1',
     key: {
+      prehash: false,
       publicKey: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
       type: 'p256',
     },
@@ -207,11 +216,7 @@ const response = await provider.request({
   method: 'wallet_sendPreparedCalls',
   params: [{
     ...request,
-    signature: {
-      publicKey: '0x...',
-      type: 'p256',
-      value: signature,
-    }
+    signature
   }]
 })
 /**

--- a/ERCS/erc-7836.md
+++ b/ERCS/erc-7836.md
@@ -75,8 +75,8 @@ type Response = {
   capabilities: Record<string, any>
   // Chain ID of the chain the calls are being submitted to.
   chainId: `0x${string}`
-  // Wallet-specific data to be forwarded to `wallet_sendPreparedCalls` 
-  // (e.g. ERC-4337 UserOperation object, bundle type, etc.).
+  // Data specific to the Wallet to be forwarded to `wallet_sendPreparedCalls` 
+  // (e.g. ERC-4337 UserOperation or alternative).
   context: unknown
   // Key (hint) that will be used to sign the call bundle.
   key?: {
@@ -154,8 +154,8 @@ type Request = {
     capabilities: Record<string, any>
     // Chain ID of the chain the calls are being submitted to.
     chainId: `0x${string}`
-    // Wallet-specific data. 
-    // (e.g. ERC-4337 UserOperation object, bundle type, etc.).
+    // Data specific to the Wallet from the `wallet_prepareCalls` response.
+    // (e.g. ERC-4337 UserOperation or alternative).
     context: unknown
     // Key that was used to sign the call bundle.
     key: {

--- a/ERCS/erc-7836.md
+++ b/ERCS/erc-7836.md
@@ -17,7 +17,7 @@ This proposal defines complementary JSON-RPC methods to [EIP-5792's `wallet_send
 
 ## Motivation
 
-With the advent of Account Abstraction (and Permissions), there is an increasing need for Applications to be able to sign and submit actions without needing to switch to a Wallet interface (e.g. browser extension). As Smart Contract Accounts (SCAs) contain opinionated execution interfaces that leads to varying calldata formats, it is not possible for an Application to know how to sign over an action for any arbitrary Account implementation. They would need to maintain a mapping of Account implementations to their signing logic.
+With the advent of Account Abstraction (and Permissions), there is an increasing need for Applications to be able to sign and submit actions without needing to switch to a Wallet interface (e.g. browser extension). As Smart Contract Accounts (SCAs) contain arbitrary execution interfaces that leads to varying calldata formats, it is not possible for an Application to know how to sign over an action for any arbitrary Account implementation. They would need to maintain a mapping of Account implementations to their signing logic.
 
 ## Specification
 

--- a/ERCS/erc-7836.md
+++ b/ERCS/erc-7836.md
@@ -2,7 +2,7 @@
 eip: 7836
 title: Wallet Call Preparation API
 description: Adds JSON-RPC methods for requesting prepared EIP-5792 calls.
-author: Lukas Rosario (@lukasrosario), Conner Swenberg (@ilikesymmetry), Adam Hodges (@ajhodges), Paaras Bhandari (@paarasbhandari)
+author: Lukas Rosario (@lukasrosario), Conner Swenberg (@ilikesymmetry), Adam Hodges (@ajhodges), Paaras Bhandari (@paarasbhandari), Jake Moxey (@jxom)
 discussions-to: https://ethereum-magicians.org/t/new-erc-wallet-call-preparation-api/22456
 status: Draft
 type: Standards Track
@@ -13,140 +13,175 @@ requires: 1193, 5792
 
 ## Abstract
 
-This proposal defines complementary JSON-RPC methods to [EIP-5792](./eip-5792.md)'s `wallet_sendCalls`. While `wallet_sendCalls` is used for an app to submit `calls` to be signed and submitted in a wallet's interface, the methods in this proposal are for an application to request prepared calls (where "prepared" depends on the wallet implementation) to be signed and submitted by the application itself.
+This proposal defines complementary JSON-RPC methods to [EIP-5792's `wallet_sendCalls`](./eip-5792.md) to enable an Application to sign over a call bundle (instead of the Wallet). Methods defined in this proposal are purposed for the Application to sign over `calls` and submit them to the Wallet with an accompanying signature. This is in contrast to `wallet_sendCalls`, where a Wallet itself signs over the call bundle.
 
 ## Motivation
 
-With more recent developments in account abstraction and session keys, there is an increasing need for applications to be able to sign and submit operations without switching to a wallet interface (e.g. browser extension). This can be tricky because different account implementations might have different call data encoding, signature formats, etc. To remedy this, we need a way for apps to know how to submit an operation for any account implementation.
+With the advent of Account Abstraction (and Account Permissions), there is an increasing need for Applications to be able to sign and submit actions without needing to switch to a Wallet interface (e.g. browser extension). As Smart Contract Accounts (SCAs) contain opinionated execution interfaces that leads to varying calldata formats, it is not possible for an Application to know how to sign over an action for any arbitrary Account implementation. They would need to maintain a mapping of Account implementations to their signing logic.
 
 ## Specification
 
-Two new JSON-RPC methods are defined. If the user is interacting with an application on the browser, they can be used by sending the requests to the wallet's [EIP-1193](./eip-1193.md) provider. However, this proposal also describes how an application might interact with a "wallet server" for background processes.
+In this specification, we define two new JSON-RPC methods: `wallet_prepareCalls` and `wallet_sendPreparedCalls`.
 
 ### `wallet_prepareCalls`
 
-Accepts an EIP-5792 `wallet_sendCalls` request, and returns the prepared calls according to the account's implementation.
+Instructs a Wallet to prepare a call bundle according to the Account's implementation. It returns a `digest` of the call bundle to sign over, as well as the parameters required to fulfil a `wallet_sendPreparedCalls` request (ie. `capabilities`, `chainId`, `context`, and `version`).
 
-#### Parameters
+> After calling `wallet_prepareCalls`, consumers are expected to sign over the `digest` and submit the `signature` and prepared calls to the Wallet via `wallet_sendPreparedCalls`.
 
-```typescript!
-type PrepareCallsParams = [{
+#### Request
+
+> The request is identical to that of [`wallet_sendCalls`](./eip-5792.md).
+
+```typescript
+type Request = {
+  method: 'wallet_prepareCalls',
+  params: [{
+    version: string;
+    chainId: `0x${string}`;
+    from?: `0x${string}`;
+    calls: {
+      to: `0x${string}`;
+      data?: `0x${string}`;
+      value?: `0x${string}`;
+      capabilities?: Record<string, any>;
+    }[];
+    capabilities?: Record<string, any>
+  }]
+}
+```
+
+#### Response
+
+> The response is intended to be forwarded to `wallet_sendPreparedCalls` (minus the `digest`).
+
+```typescript
+type Response = {
+  // Capabilities to be forwarded to `wallet_sendPreparedCalls`.
+  capabilities: Record<string, any>
+  // Chain ID of the chain the calls are being submitted to.
+  chainId: `0x${string}`
+  // Wallet-specific data to be forwarded to `wallet_sendPreparedCalls` 
+  // (e.g. ERC-4337 UserOperation object, bundle type, etc.).
+  context: unknown
+  // Digest of the call bundle to sign over.
+  digest: `0x${string}`
+  // JSON-RPC method version.
   version: string
-  from: `0x${string}`
-  chainId: `0x${string}`
-  calls: {
-    to: `0x${string}`
-    data: `0x${string}`
-    value: `0x${string}`
-  }[];
-  capabilities: Record<string, any>
-}]
+}
 ```
 
-##### Example Parameters
+#### Example
 
-```typescript!
-wallet_prepareCalls([{
-  version: '1.0',
-  from: '0x...',
-  chainId: '0x...',
-  calls: [{
-    to: '0x...'
-    data: '0x...'
-    value: '0x...'
-  }],
-  capabilities: {
-    paymasterService: {
-      url: 'https://...'
-    }
-  }
-}])
+```typescript
+const response = await provider.request({
+  method: 'wallet_prepareCalls',
+  params: [{
+    calls: [{
+      to: '0xcafebabecafebabecafebabecafebabecafebabe',
+      data: '0xdeadbeef',
+    }],
+    capabilities: {
+      paymasterService: {
+        url: 'https://...',
+      },
+    },
+    chainId: '0x1',
+    version: '1',
+  }]
+})
+/**
+ * {
+ *   capabilities: {
+ *     paymasterService: {
+ *       url: 'https://...'
+ *     }
+ *   },
+ *   chainId: '0x1',
+ *   context: { ... },
+ *   signatureRequest: {
+ *     digest: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+ *   },
+ *   version: '1',
+ * }
+ */
 ```
-
-#### Return Value
-
-```typescript!
-type PrepareCallsReturnValue = {
-  type: string
-  chainId: `0x${string}`
-  signatureRequest: {
-    hash: `0x${string}`
-  }
-  capabilities: Record<string, any>
-}
-##### Example Return Value
-
-```typescript!
-{
-  type: 'user-operation-v06',
-  userOp: {
-    sender: '0x...',
-    ...
-  },
-  chainId: '0x01',
-  signatureRequest: {
-    hash: '0x...'
-  }
-  capabilities: {
-    paymasterService: {
-      sponsor: 'My app'
-    }
-  }
-}
-After calling `wallet_prepareCalls`, app developers are expected to sign the hash provided in the `signatureRequest` field and submit the prepared and signed calls back to the wallet (either via its [EIP-1193](./eip-1193.md) provider or to its server counterpart) using the second RPC method, `wallet_sendPreparedCalls`.
 
 ### `wallet_sendPreparedCalls`
 
-Accepts prepared calls from the response to a `wallet_prepareCalls` request along with a signature, and returns an EIP-5792 call bundle ID.
+Instructs a Wallet to execute a prepared call bundle (response of `wallet_prepareCalls`) with an accompanying `signature`. 
 
 #### Parameters
 
-```typescript!
-type SendPreparedCallsParams = [{
-  version: string
-  type: string
-  data: any
-  chainId: `0x${string}`
-  signature: {
-    type: string
+> The request is identical to the response of `wallet_prepareCalls`, except that it includes a `signature`.
+
+```typescript
+type Request = {
+  method: 'wallet_sendPreparedCalls',
+  params: [{
+    // Capabilities.
+    capabilities: Record<string, any>
+    // Chain ID of the chain the calls are being submitted to.
+    chainId: `0x${string}`
+    // Wallet-specific data. 
+    // (e.g. ERC-4337 UserOperation object, bundle type, etc.).
+    context: unknown
+    // Signature of the call bundle.
     signature: `0x${string}`
-  }
-}]
-```
-
-##### Example Parameters
-
-```typescript!
-wallet_sendPreparedCalls([{
-  version: '1.0',
-  type: 'user-operation-v06',
-  data: {
-    sender: '0x...',
-    ...
-  },
-  chainId: '0x01',
-  signature: {
-    type: 'secp256k1',
-    data: '0x...'
-  }
-}])
-```
-
-#### Return Value
-
-```typescript!
-type SendPreparedCallsReturnValue = {
-  preparedCallIds: string[]
+    // JSON-RPC method version.
+    version: string
+  }]
 }
 ```
 
-##### Example Return Value
+#### Response
 
-```typescript!
-['0x...']
+> The response is identical to that of `wallet_sendCalls`, except that it is a list.
+
+```typescript
+type Response = {
+  id: string,
+  capabilities: Record<string, any>
+}[]
 ```
 
-The `wallet_sendPreparedCalls` RPC responds with EIP-5792 call bundle identifiers, so apps that already use `wallet_sendCalls` to submit calls to the wallet can continue to use `wallet_getCallsStatus` to get the status of submitted calls.
+#### Example
+
+```typescript
+const request = await provider.request({
+  method: 'wallet_prepareCalls',
+  params: [{
+    calls: [{
+      to: '0xcafebabecafebabecafebabecafebabecafebabe',
+      data: '0xdeadbeef',
+    }],
+    capabilities: {
+      paymasterService: {
+        url: 'https://...',
+      },
+    },
+    chainId: '0x1',
+    version: '1',
+  }]
+})
+
+const signature = sign(request.digest)
+
+const response = await provider.request({
+  method: 'wallet_sendPreparedCalls',
+  params: [{
+    ...request,
+    signature
+  }]
+})
+/**
+ * [
+ *   {
+ *     id: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+ *   }
+ * ]
+ */
+```
 
 ## Rationale
 

--- a/ERCS/erc-7836.md
+++ b/ERCS/erc-7836.md
@@ -37,16 +37,28 @@ Instructs a Wallet to prepare a call bundle according to the Account's implement
 type Request = {
   method: 'wallet_prepareCalls',
   params: [{
-    version: string;
-    chainId: `0x${string}`;
-    from?: `0x${string}`;
+    // Calls to be executed.
     calls: {
       to: `0x${string}`;
       data?: `0x${string}`;
       value?: `0x${string}`;
       capabilities?: Record<string, any>;
     }[];
+    // Capabilities.
     capabilities?: Record<string, any>
+    // Chain ID of the chain the calls are being submitted to.
+    chainId: `0x${string}`;
+    // Sender address.
+    from?: `0x${string}`;
+    // Key that will be used to sign the call bundle.
+    key?: {
+      // Public key.
+      publicKey: `0x${string}`,
+      // Key type.
+      type: 'secp256k1' | 'p256' | 'webauthn-p256' | 'webcrypto-p256'
+    };
+    // JSON-RPC method version.
+    version: string;
   }]
 }
 ```
@@ -64,6 +76,13 @@ type Response = {
   // Wallet-specific data to be forwarded to `wallet_sendPreparedCalls` 
   // (e.g. ERC-4337 UserOperation object, bundle type, etc.).
   context: unknown
+  // Key that will be used to sign the call bundle.
+  key: {
+    // Public key.
+    publicKey: `0x${string}`,
+    // Key type.
+    type: 'secp256k1' | 'p256' | 'webauthn-p256' | 'webcrypto-p256'
+  },
   // Digest of the call bundle to sign over.
   digest: `0x${string}`
   // JSON-RPC method version.
@@ -87,6 +106,10 @@ const response = await provider.request({
       },
     },
     chainId: '0x1',
+    key: {
+      publicKey: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+      type: 'p256',
+    },
     version: '1',
   }]
 })
@@ -99,8 +122,10 @@ const response = await provider.request({
  *   },
  *   chainId: '0x1',
  *   context: { ... },
- *   signatureRequest: {
- *     digest: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+ *   digest: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+ *   key: {
+ *     publicKey: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+ *     type: 'p256',
  *   },
  *   version: '1',
  * }
@@ -126,15 +151,15 @@ type Request = {
     // Wallet-specific data. 
     // (e.g. ERC-4337 UserOperation object, bundle type, etc.).
     context: unknown
-    // Signature of the call bundle.
-    signature: {
-      // Public key that generated the signature.
+    // Key that was used to sign the call bundle.
+    key: {
+      // Public key.
       publicKey: `0x${string}`,
-      // Signature type (e.g. secp256k1, p256, etc).
-      type: string,
-      // Signature value.
-      value: `0x${string}`,
-    }
+      // Key type.
+      type: 'secp256k1' | 'p256' | 'webauthn-p256' | 'webcrypto-p256'
+    },
+    // Signature of the call bundle.
+    signature: `0x${string}`
     // JSON-RPC method version.
     version: string
   }]
@@ -155,7 +180,7 @@ type Response = {
 #### Example
 
 ```typescript
-const request = await provider.request({
+const { digest, ...request } = await provider.request({
   method: 'wallet_prepareCalls',
   params: [{
     calls: [{
@@ -168,11 +193,15 @@ const request = await provider.request({
       },
     },
     chainId: '0x1',
+    key: {
+      publicKey: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+      type: 'p256',
+    },
     version: '1',
   }]
 })
 
-const signature = p256.sign(request.digest, privateKey)
+const signature = p256.sign(digest, privateKey)
 
 const response = await provider.request({
   method: 'wallet_sendPreparedCalls',

--- a/ERCS/erc-7836.md
+++ b/ERCS/erc-7836.md
@@ -127,7 +127,12 @@ type Request = {
     // (e.g. ERC-4337 UserOperation object, bundle type, etc.).
     context: unknown
     // Signature of the call bundle.
-    signature: `0x${string}`
+    signature: {
+      // Signature type (e.g. secp256k1, p256, etc).
+      type: string,
+      // Signature value.
+      value: `0x${string}`,
+    }
     // JSON-RPC method version.
     version: string
   }]
@@ -165,13 +170,16 @@ const request = await provider.request({
   }]
 })
 
-const signature = sign(request.digest)
+const signature = p256.sign(request.digest, privateKey)
 
 const response = await provider.request({
   method: 'wallet_sendPreparedCalls',
   params: [{
     ...request,
-    signature
+    signature: {
+      type: 'p256',
+      value: signature,
+    }
   }]
 })
 /**

--- a/ERCS/erc-7836.md
+++ b/ERCS/erc-7836.md
@@ -50,10 +50,10 @@ type Request = {
     chainId: `0x${string}`;
     // Sender address.
     from?: `0x${string}`;
-    // Key that will be used to sign the call bundle.
+    // Key (hint) that will be used to sign the call bundle.
     key?: {
       // Whether the digest will be prehashed by the key (default behavior of WebCrypto APIs).
-      prehash: boolean,
+      prehash?: boolean,
       // Public key.
       publicKey: `0x${string}`,
       // Key type.
@@ -78,8 +78,8 @@ type Response = {
   // Wallet-specific data to be forwarded to `wallet_sendPreparedCalls` 
   // (e.g. ERC-4337 UserOperation object, bundle type, etc.).
   context: unknown
-  // Key that will be used to sign the call bundle.
-  key: {
+  // Key (hint) that will be used to sign the call bundle.
+  key?: {
     // Whether the digest will be prehashed by the key (default behavior of WebCrypto APIs).
     prehash: boolean,
     // Public key.
@@ -160,7 +160,7 @@ type Request = {
     // Key that was used to sign the call bundle.
     key: {
       // Whether the digest will be prehashed by the key (default behavior of WebCrypto APIs).
-      prehash: boolean,
+      prehash?: boolean,
       // Public key.
       publicKey: `0x${string}`,
       // Key type.


### PR DESCRIPTION
[View Formatted](https://github.com/lukasrosario/ERCs/blob/bc63d3ff07ac71c56719ffbfd47194cd986c393c/ERCS/erc-7836.md)

Suggesting a few tweaks to the ERC:

- Made various language tweaks.

- Updated `wallet_prepareCalls` parameters and `wallet_sendPreparedCalls` return type to match ERC-5792 `wallet_sendCalls` parameters and return type.

- `wallet_prepareCalls` Parameters
  - Renamed `data` to `context`: I think `context` may be more appropriate here for forwarding wallet-specific data to be utilized in `wallet_sendPreparedCalls`? It would remove ambiguity between "calldata" data and "preparation" data.
  - Modified `signatureRequest` to `digest`: I think it is okay to just return a simple digest field for a consumer to sign over, instead of nested properties? The term "digest" might be more future-proof than "hash" too.
  - Added optional `key` hint parameter: some entities need a hint on the type of key that will sign the request to prepare accurately.
  
- `wallet_prepareCalls` Return Type
  - Removed `type` property: I believe this can just be encapsulated in `context` if the Wallet wishes to use this in `wallet_sendPreparedCalls`, plus I don't think the consumer should be concerned of the orchestration type (e.g. user op, vs. transaction vs. something else)?
  
- `wallet_sendPreparedCalls` Parameters
  - Condensed `signature` from an object to a hex string, as we now have the `key` property that will indicate the key (type) that signed over the digest.